### PR TITLE
Implement referrer and server name

### DIFF
--- a/src/HtaccessClient.php
+++ b/src/HtaccessClient.php
@@ -23,8 +23,12 @@ final class HtaccessClient
         $this->requestFactory = $requestFactory;
     }
 
-    public function test(string $url, string $htaccess, string $referrer = ''): HtaccessResult
-    {
+    public function test(
+        string $url,
+        string $htaccess,
+        ?string $referrer = '',
+        ?string $serverName = ''
+    ): HtaccessResult {
         $request = $this->requestFactory->createServerRequest(
             'POST',
             'https://htaccess.madewithlove.be/api'
@@ -34,8 +38,8 @@ final class HtaccessClient
         $body->write(json_encode([
             'url' => $url,
             'htaccess' => $htaccess,
-            'referrer' => $referrer,
-            'serverName' => '',
+            'referrer' => $referrer ?? '',
+            'serverName' => $serverName ?? '',
         ]));
 
         $request = $request

--- a/src/HtaccessClient.php
+++ b/src/HtaccessClient.php
@@ -23,7 +23,7 @@ final class HtaccessClient
         $this->requestFactory = $requestFactory;
     }
 
-    public function test(string $url, string $htaccess): HtaccessResult
+    public function test(string $url, string $htaccess, string $referrer = ''): HtaccessResult
     {
         $request = $this->requestFactory->createServerRequest(
             'POST',
@@ -34,7 +34,7 @@ final class HtaccessClient
         $body->write(json_encode([
             'url' => $url,
             'htaccess' => $htaccess,
-            'referrer' => '',
+            'referrer' => $referrer,
             'serverName' => '',
         ]));
 

--- a/tests/HtaccessClientTest.php
+++ b/tests/HtaccessClientTest.php
@@ -39,4 +39,25 @@ final class HtaccessClientTest extends TestCase
             $response->getLines()
         );
     }
+
+    /** @test */
+    public function it allows for passing a referrer(): void
+    {
+        $client = new HtaccessClient(
+            new Client(),
+            new ServerRequestFactory()
+        );
+
+        $response = $client->test(
+            'http://localhost',
+            'RewriteCond %{HTTP_REFERER} http://example.com
+             RewriteRule .* /example-page [L]',
+            'http://example.com'
+        );
+
+        $this->assertEquals(
+            'http://localhost/example-page',
+            $response->getOutputUrl()
+        );
+    }
 }

--- a/tests/HtaccessClientTest.php
+++ b/tests/HtaccessClientTest.php
@@ -60,4 +60,26 @@ final class HtaccessClientTest extends TestCase
             $response->getOutputUrl()
         );
     }
+
+    /** @test */
+    public function it allows for passing a server name(): void
+    {
+        $client = new HtaccessClient(
+            new Client(),
+            new ServerRequestFactory()
+        );
+
+        $response = $client->test(
+            'http://localhost',
+            'RewriteCond %{SERVER_NAME} example.com
+             RewriteRule .* /example-page [L]',
+            null,
+            'example.com'
+        );
+
+        $this->assertEquals(
+            'http://localhost/example-page',
+            $response->getOutputUrl()
+        );
+    }
 }


### PR DESCRIPTION
This PR adds the optional "referrer" and "server name" fields which are available in the Htaccess tester API.