### PR TITLE
Add error handling

### DIFF
--- a/src/HtaccessClient.php
+++ b/src/HtaccessClient.php
@@ -23,6 +23,9 @@ final class HtaccessClient
         $this->requestFactory = $requestFactory;
     }
 
+    /**
+     * @throws HtaccessException
+     */
     public function test(
         string $url,
         string $htaccess,

--- a/src/HtaccessClient.php
+++ b/src/HtaccessClient.php
@@ -50,9 +50,7 @@ final class HtaccessClient
         $responseData = json_decode($response->getBody()->getContents(), true);
 
         if (isset($responseData['errors'])) {
-            throw new HtaccessException(
-                json_encode($responseData['errors'])
-            );
+            throw HtaccessException::fromApiErrors($responseData['errors']);
         }
 
         return new HtaccessResult(

--- a/src/HtaccessClient.php
+++ b/src/HtaccessClient.php
@@ -49,6 +49,12 @@ final class HtaccessClient
         $response = $this->httpClient->sendRequest($request);
         $responseData = json_decode($response->getBody()->getContents(), true);
 
+        if (isset($responseData['errors'])) {
+            throw new HtaccessException(
+                json_encode($responseData['errors'])
+            );
+        }
+
         return new HtaccessResult(
             $responseData['output_url'],
             array_map(

--- a/src/HtaccessException.php
+++ b/src/HtaccessException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Madewithlove;
+
+use Exception;
+
+class HtaccessException extends Exception
+{
+}

--- a/src/HtaccessException.php
+++ b/src/HtaccessException.php
@@ -6,4 +6,15 @@ use Exception;
 
 class HtaccessException extends Exception
 {
+    public static function fromApiErrors(array $errors): self
+    {
+        $errorMessages = array_map(
+            function (array $error): string {
+                return $error['field'] . ': ' . $error['message'];
+            },
+            $errors
+        );
+
+        return new static(implode("\n", $errorMessages));
+    }
 }

--- a/tests/HtaccessClientTest.php
+++ b/tests/HtaccessClientTest.php
@@ -2,9 +2,9 @@
 
 namespace Madewithlove;
 
+use Http\Adapter\Guzzle6\Client;
 use Http\Factory\Guzzle\ServerRequestFactory;
 use PHPUnit\Framework\TestCase;
-use Http\Adapter\Guzzle6\Client;
 
 final class HtaccessClientTest extends TestCase
 {
@@ -80,6 +80,21 @@ final class HtaccessClientTest extends TestCase
         $this->assertEquals(
             'http://localhost/example-page',
             $response->getOutputUrl()
+        );
+    }
+
+    /** @test */
+    public function it throws an exception when we pass an invalid url(): void
+    {
+        $client = new HtaccessClient(
+            new Client(),
+            new ServerRequestFactory()
+        );
+
+        $this->expectException(HtaccessException::class);
+        $client->test(
+            'http:localhost',
+            'RewriteRule .* /example-page [L]'
         );
     }
 }

--- a/tests/HtaccessClientTest.php
+++ b/tests/HtaccessClientTest.php
@@ -98,4 +98,20 @@ final class HtaccessClientTest extends TestCase
             'RewriteRule .* /example-page [L]'
         );
     }
+
+    /** @test */
+    public function it throws an exception when we pass multiple invalid fields(): void
+    {
+        $client = new HtaccessClient(
+            new Client(),
+            new ServerRequestFactory()
+        );
+
+        $this->expectExceptionMessage("url: This is not a valid url\nhtaccess: htaccess must not be empty");
+        $this->expectException(HtaccessException::class);
+        $client->test(
+            'http:localhost',
+            ''
+        );
+    }
 }

--- a/tests/HtaccessClientTest.php
+++ b/tests/HtaccessClientTest.php
@@ -91,6 +91,7 @@ final class HtaccessClientTest extends TestCase
             new ServerRequestFactory()
         );
 
+        $this->expectExceptionMessage('url: This is not a valid url');
         $this->expectException(HtaccessException::class);
         $client->test(
             'http:localhost',


### PR DESCRIPTION
This makes sure that when the API returns a list of errors, we throw a custom exception containing easily readable errors.