### PR TITLE
Fix PHPStan build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,7 @@ jobs:
     - uses: actions/checkout@master
     - name: PHPStan
       uses: docker://oskarstark/phpstan-ga
+      env:
+        REQUIRE_DEV: true
       with:
         args: analyse


### PR DESCRIPTION
The phpstan check changed to not install dev dependencies by default,
which is necessary to let PHPStan cover your testsuite