### PR TITLE
Add mutation testing using Infection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install dependencies
       run: composer install -n --prefer-dist
     - name: Run mutation tests
-      run: vendor/bin/infection --min-msi=90 --min-covered-msi=90 --show-mutations
+      run: vendor/bin/infection --min-msi=85 --min-covered-msi=85 --show-mutations
 
   phpstan:
     name: PHPStan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,20 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
       if: matrix.php-versions == '7.3'
+
+  infection:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['7.2', '7.3']
+    steps:
+    - uses: actions/checkout@v1
+    - uses: shivammathur/setup-php@v1
+      with:
+        php-version: ${{ matrix.php-versions }}
+        coverage: pcov
+    - name: Install dependencies
+      run: composer install -n --prefer-dist
     - name: Run mutation tests
       run: vendor/bin/infection --min-msi=100 --min-covered-msi=100 --show-mutations
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3']
+        php-versions: ['7.2', '7.3', '7.4']
     steps:
     - uses: actions/checkout@v1
     - uses: shivammathur/setup-php@v1
@@ -20,13 +20,13 @@ jobs:
     - uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-      if: matrix.php-versions == '7.3'
+      if: matrix.php-versions == '7.4'
 
   infection:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3']
+        php-versions: ['7.2', '7.3', '7.4']
     steps:
     - uses: actions/checkout@v1
     - uses: shivammathur/setup-php@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install dependencies
       run: composer install -n --prefer-dist
     - name: Run mutation tests
-      run: vendor/bin/infection --min-msi=100 --min-covered-msi=100 --show-mutations
+      run: vendor/bin/infection --min-msi=90 --min-covered-msi=90 --show-mutations
 
   phpstan:
     name: PHPStan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
       if: matrix.php-versions == '7.3'
+    - name: Run mutation tests
+      run: vendor/bin/infection --min-msi=100 --min-covered-msi=100 --show-mutations
 
   phpstan:
     name: PHPStan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: composer install -n --prefer-dist
     - name: Run PHPUnit unit tests
-      run: vendor/bin/phpunit tests/ --coverage-clover=build/logs/clover.xml --whitelist src/
+      run: vendor/bin/phpunit --coverage-clover=build/logs/clover.xml --whitelist src/
     - uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 composer.lock
+*.cache

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require-dev": {
         "phpunit/phpunit": "^8.4",
         "php-http/guzzle6-adapter": "^2.0",
-        "http-interop/http-factory-guzzle": "^1.0"
+        "http-interop/http-factory-guzzle": "^1.0",
+        "infection/infection": "^0.16.3"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
         "phpunit/phpunit": "^8.4",
         "php-http/guzzle6-adapter": "^2.0",
         "http-interop/http-factory-guzzle": "^1.0",
-        "infection/infection": "^0.16.3"
+        "infection/infection": "^0.15"
     }
 }

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,0 +1,13 @@
+{
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "text": "infection.log"
+    },
+    "mutators": {
+        "@default": true
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+    colors="true">
+    <testsuite name="Tests">
+        <directory>tests</directory>
+    </testsuite>
+</phpunit>


### PR DESCRIPTION
Note that there are currently 3 mutations that aren't covered. With the current API calls we're covering, this is also not possible the handle.

Once we've implemented a method to get a shared htaccess test run, we'll be able to get rid of these mutations though.