### PR TITLE
Add "get shared" functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install dependencies
       run: composer install -n --prefer-dist
     - name: Run mutation tests
-      run: vendor/bin/infection --min-msi=85 --min-covered-msi=85 --show-mutations
+      run: vendor/bin/infection --min-msi=100 --min-covered-msi=100 --show-mutations
 
   phpstan:
     name: PHPStan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ jobs:
         php-versions: ['7.2', '7.3', '7.4']
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/cache@v1
+      with:
+        path: vendor
+        key: dependencies-${{ matrix.php-versions }}-${{ hashFiles('composer.json') }}
     - uses: shivammathur/setup-php@v1
       with:
         php-version: ${{ matrix.php-versions }}
@@ -29,6 +33,10 @@ jobs:
         php-versions: ['7.2', '7.3', '7.4']
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/cache@v1
+      with:
+        path: vendor
+        key: dependencies-${{ matrix.php-versions }}-${{ hashFiles('composer.json') }}
     - uses: shivammathur/setup-php@v1
       with:
         php-version: ${{ matrix.php-versions }}

--- a/src/HtaccessClient.php
+++ b/src/HtaccessClient.php
@@ -83,6 +83,33 @@ final class HtaccessClient
         return new ShareResult($responseData['url']);
     }
 
+    /**
+     * @throws HtaccessException
+     */
+    public function getShared(string $shareUuid): HtaccessResult
+    {
+        $responseData = $this->request(
+            'GET',
+            '/share?share=' . $shareUuid
+        );
+
+        return new HtaccessResult(
+            $responseData['output_url'],
+            array_map(
+                function (array $line) {
+                    return new ResultLine(
+                        $line['value'],
+                        $line['message'],
+                        $line['isMet'],
+                        $line['isValid'],
+                        $line['wasReached']
+                    );
+                },
+                $responseData['lines']
+            )
+        );
+    }
+
     private function request(string $method, string $endpoint = '', array $requestData = []): array
     {
         $request = $this->requestFactory->createServerRequest(

--- a/src/HtaccessClient.php
+++ b/src/HtaccessClient.php
@@ -76,7 +76,7 @@ final class HtaccessClient
                 'url' => $url,
                 'htaccess' => $htaccess,
                 'referrer' => $referrer ?? '',
-                'serverName' => $serverName ?? '',
+                'server_name' => $serverName ?? '',
             ]
         );
 

--- a/tests/HtaccessClientTest.php
+++ b/tests/HtaccessClientTest.php
@@ -163,4 +163,37 @@ final class HtaccessClientTest extends TestCase
             $sharedResult->getLines()
         );
     }
+
+    /** @test */
+    public function it can share a test run with a referer(): void
+    {
+        $client = new HtaccessClient(
+            new Client(),
+            new ServerRequestFactory()
+        );
+
+        $response = $client->share(
+            'http://localhost',
+            'RewriteCond %{HTTP_REFERER} http://example.com
+             RewriteRule .* /example-page [L]',
+            'http://example.com'
+        );
+
+        $this->assertStringStartsWith(
+            'https://htaccess.madewithlove.be',
+            $response->getShareUrl()
+        );
+        $this->assertRegExp(
+            '#.*?share=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}#',
+            $response->getShareUrl()
+        );
+
+        $shareUuid = substr($response->getShareUrl(), -36);
+        $sharedResult = $client->getShared($shareUuid);
+
+        $this->assertEquals(
+            'http://localhost/example-page',
+            $sharedResult->getOutputUrl()
+        );
+    }
 }

--- a/tests/HtaccessClientTest.php
+++ b/tests/HtaccessClientTest.php
@@ -130,10 +130,7 @@ final class HtaccessClientTest extends TestCase
 
         $response = $client->share(
             'http://localhost',
-            'RewriteCond %{SERVER_NAME} example.com
-             RewriteRule .* /example-page [L]',
-            null,
-            'example.com'
+            'RewriteRule .* /foo [R]'
         );
 
         $this->assertStringStartsWith(
@@ -143,6 +140,27 @@ final class HtaccessClientTest extends TestCase
         $this->assertRegExp(
             '#.*?share=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}#',
             $response->getShareUrl()
+        );
+
+        $shareUuid = substr($response->getShareUrl(), -36);
+        $sharedResult = $client->getShared($shareUuid);
+
+        $this->assertEquals(
+            'http://localhost/foo',
+            $sharedResult->getOutputUrl()
+        );
+
+        $this->assertEquals(
+            [
+                new ResultLine(
+                    'RewriteRule .* /foo [R]',
+                    "The new url is http://localhost/foo\nTest are stopped, a redirect will be made with status code 302",
+                    true,
+                    true,
+                    true
+                ),
+            ],
+            $sharedResult->getLines()
         );
     }
 }

--- a/tests/HtaccessClientTest.php
+++ b/tests/HtaccessClientTest.php
@@ -196,4 +196,38 @@ final class HtaccessClientTest extends TestCase
             $sharedResult->getOutputUrl()
         );
     }
+
+    /** @test */
+    public function it can share a test run with a server name(): void
+    {
+        $client = new HtaccessClient(
+            new Client(),
+            new ServerRequestFactory()
+        );
+
+        $response = $client->share(
+            'http://localhost',
+            'RewriteCond %{SERVER_NAME} example.com
+             RewriteRule .* /example-page [L]',
+            null,
+            'example.com'
+        );
+
+        $this->assertStringStartsWith(
+            'https://htaccess.madewithlove.be',
+            $response->getShareUrl()
+        );
+        $this->assertRegExp(
+            '#.*?share=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}#',
+            $response->getShareUrl()
+        );
+
+        $shareUuid = substr($response->getShareUrl(), -36);
+        $sharedResult = $client->getShared($shareUuid);
+
+        $this->assertEquals(
+            'http://localhost/example-page',
+            $sharedResult->getOutputUrl()
+        );
+    }
 }


### PR DESCRIPTION
This PR adds the "get shared" functionality, which allows us to add some additional tests for the share functionality, killing all mutants found by infection and actually squashing a bug as well.