### PR TITLE
Add support for PHP 8 and drop support for PHP7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,11 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         coverage: pcov
     - name: Install dependencies
+      run: composer install -n --prefer-dist
+      if: matrix.php-versions != '8.0'
+    - name: Install dependencies
       run: composer self-update --snapshot && composer install -n --prefer-dist --ignore-platform-req=php
+      if: matrix.php-versions == '8.0'
     - name: Run PHPUnit unit tests
       run: vendor/bin/phpunit --coverage-clover=build/logs/clover.xml --whitelist src/
     - uses: codecov/codecov-action@v1
@@ -42,7 +46,11 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         coverage: pcov
     - name: Install dependencies
+      run: composer install -n --prefer-dist
+      if: matrix.php-versions != '8.0'
+    - name: Install dependencies
       run: composer self-update --snapshot && composer install -n --prefer-dist --ignore-platform-req=php
+      if: matrix.php-versions == '8.0'
     - name: Run mutation tests
       run: vendor/bin/infection --min-msi=100 --min-covered-msi=100 --show-mutations
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         coverage: pcov
     - name: Install dependencies
-      run: composer install -n --prefer-dist
+      run: composer self-update --snapshot && composer install -n --prefer-dist --ignore-platform-req=php
     - name: Run PHPUnit unit tests
       run: vendor/bin/phpunit --coverage-clover=build/logs/clover.xml --whitelist src/
     - uses: codecov/codecov-action@v1
@@ -42,7 +42,7 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         coverage: pcov
     - name: Install dependencies
-      run: composer install -n --prefer-dist
+      run: composer self-update --snapshot && composer install -n --prefer-dist --ignore-platform-req=php
     - name: Run mutation tests
       run: vendor/bin/infection --min-msi=100 --min-covered-msi=100 --show-mutations
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.2', '7.3', '7.4']
     steps:
     - uses: actions/checkout@v1
     - uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
     steps:
     - uses: actions/checkout@v1
     - uses: actions/cache@v1
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
     steps:
     - uses: actions/checkout@v1
     - uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       run: composer self-update --snapshot && composer install -n --prefer-dist --ignore-platform-req=php
       if: matrix.php-versions == '8.0'
     - name: Run mutation tests
-      run: vendor/bin/infection --min-msi=100 --min-covered-msi=100 --show-mutations
+      run: vendor/bin/infection --min-msi=100 --min-covered-msi=100 --show-mutations --debug -vvv
 
   phpstan:
     name: PHPStan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4', '8.0']
     steps:
     - uses: actions/checkout@v1
     - uses: actions/cache@v1
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4']
     steps:
     - uses: actions/checkout@v1
     - uses: actions/cache@v1

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "API client for the best htaccess tester in the world.",
     "type": "package",
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "API client for the best htaccess tester in the world.",
     "type": "package",
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^7.3|^8.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "license": "GPL-3.0-or-later",
     "require-dev": {
-        "phpunit/phpunit": "^8.4 || ^9.0",
+        "phpunit/phpunit": "^9.1",
         "php-http/guzzle6-adapter": "^2.0",
         "http-interop/http-factory-guzzle": "^1.0",
         "infection/infection": "^0.15|^0.16"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php"
+    convertWarningsToExceptions="false"
     colors="true">
     <testsuite name="Tests">
         <directory>tests</directory>

--- a/tests/HtaccessClientTest.php
+++ b/tests/HtaccessClientTest.php
@@ -137,7 +137,7 @@ final class HtaccessClientTest extends TestCase
             'https://htaccess.madewithlove.be',
             $response->getShareUrl()
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '#.*?share=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}#',
             $response->getShareUrl()
         );
@@ -183,7 +183,7 @@ final class HtaccessClientTest extends TestCase
             'https://htaccess.madewithlove.be',
             $response->getShareUrl()
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '#.*?share=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}#',
             $response->getShareUrl()
         );
@@ -217,7 +217,7 @@ final class HtaccessClientTest extends TestCase
             'https://htaccess.madewithlove.be',
             $response->getShareUrl()
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '#.*?share=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}#',
             $response->getShareUrl()
         );


### PR DESCRIPTION
This PR makes sure the api client works on PHP8.0 as well

Todo:

* make sure infection tests also run against PHP8.0 once https://github.com/thecodingmachine/safe/issues/225 is resolved
* drop the `ignore-platform-req=php` once all dependencies have native PHP8 support