### PR TITLE
Make status code available in the HtaccessResult value object

### DIFF
--- a/src/HtaccessClient.php
+++ b/src/HtaccessClient.php
@@ -57,7 +57,8 @@ final class HtaccessClient
                     );
                 },
                 $responseData['lines']
-            )
+            ),
+            $responseData['output_status_code']
         );
     }
 
@@ -108,7 +109,8 @@ final class HtaccessClient
                     );
                 },
                 $responseData['lines']
-            )
+            ),
+            $responseData['output_status_code']
         );
     }
 

--- a/src/HtaccessResult.php
+++ b/src/HtaccessResult.php
@@ -14,9 +14,18 @@ final class HtaccessResult
      */
     private $lines = [];
 
-    public function __construct(string $outputUrl, array $lines)
-    {
+    /**
+     * @var int?
+     */
+    private $outputStatusCode;
+
+    public function __construct(
+        string $outputUrl,
+        array $lines,
+        ?int $outputStatusCode
+    ) {
         $this->outputUrl = $outputUrl;
+        $this->outputStatusCode = $outputStatusCode;
 
         foreach ($lines as $line) {
             $this->addLine($line);
@@ -34,6 +43,11 @@ final class HtaccessResult
     public function getLines(): array
     {
         return $this->lines;
+    }
+
+    public function getOutputStatusCode(): ?int
+    {
+        return $this->outputStatusCode;
     }
 
     private function addLine(ResultLine $line): void

--- a/tests/HtaccessClientTest.php
+++ b/tests/HtaccessClientTest.php
@@ -18,7 +18,7 @@ final class HtaccessClientTest extends TestCase
 
         $response = $client->test(
             'http://localhost',
-            'RewriteRule .* /foo [R]'
+            'RewriteRule .* /foo [R=301]'
         );
 
         $this->assertEquals(
@@ -27,10 +27,15 @@ final class HtaccessClientTest extends TestCase
         );
 
         $this->assertEquals(
+            301,
+            $response->getOutputStatusCode()
+        );
+
+        $this->assertEquals(
             [
                 new ResultLine(
-                    'RewriteRule .* /foo [R]',
-                    "The new url is http://localhost/foo\nTest are stopped, a redirect will be made with status code 302",
+                    'RewriteRule .* /foo [R=301]',
+                    "The new url is http://localhost/foo\nTest are stopped, a redirect will be made with status code 301",
                     true,
                     true,
                     true,


### PR DESCRIPTION
This might enable us to make https://github.com/madewithlove/htaccess-cli/issues/51 possible