### PR TITLE
Improve test suite by running both with lowest and highest possible dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,15 @@ jobs:
     strategy:
       matrix:
         php-versions: ['7.3', '7.4', '8.0']
+        prefer-lowest: ['', '--prefer-lowest']
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/cache@v1
-      with:
-        path: vendor
-        key: dependencies-${{ matrix.php-versions }}-${{ hashFiles('composer.json') }}
     - uses: shivammathur/setup-php@master
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: pcov
     - name: Install dependencies
-      run: composer install -n --prefer-dist
+      run: composer update -n --prefer-dist ${{ matrix.prefer-lowest }}
     - name: Run unit tests
       run: vendor/bin/phpunit --coverage-clover=build/logs/clover.xml --whitelist src/
     - uses: codecov/codecov-action@v1

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "php": "^7.3|^8.0",
         "psr/http-client": "^1.0",
-        "psr/http-factory": "^1.0"
+        "psr/http-factory": "^1.0",
+        "php-http/guzzle7-adapter": "^1.0"
     },
     "autoload": {
         "psr-4": {"Madewithlove\\": "src/"}
@@ -16,7 +17,6 @@
     "license": "GPL-3.0-or-later",
     "require-dev": {
         "phpunit/phpunit": "^9.1",
-        "php-http/guzzle6-adapter": "^2.0",
         "http-interop/http-factory-guzzle": "^1.0",
         "infection/infection": "^0.15|^0.16|^0.17|^0.18|^0.19|^0.20",
         "phpstan/phpstan": "^0.12.88"

--- a/tests/HtaccessClientTest.php
+++ b/tests/HtaccessClientTest.php
@@ -2,7 +2,7 @@
 
 namespace Madewithlove;
 
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Factory\Guzzle\ServerRequestFactory;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
This is quite important for a library, especially because we try to widen the allowed versions.

Note that I had to bump the guzzle PHP client because the lowest guzzle 6 adapter said it supported PHP 8 but it did not.
This is purely a dev dependency so not relevant to the library itself, so no need to widen supported versions here.

I also already made these checks required for merge requests to be mergeable