### PR TITLE
2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "API client for the best htaccess tester in the world.",
     "type": "package",
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.4|^8.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0"
     },

--- a/src/HtaccessClient.php
+++ b/src/HtaccessClient.php
@@ -7,15 +7,8 @@ use Psr\Http\Message\ServerRequestFactoryInterface;
 
 final class HtaccessClient
 {
-    /**
-     * @var ClientInterface
-     */
-    private $httpClient;
-
-    /**
-     * @var ServerRequestFactoryInterface
-     */
-    private $requestFactory;
+    private ClientInterface $httpClient;
+    private ServerRequestFactoryInterface $requestFactory;
 
     public function __construct(ClientInterface $httpClient, ServerRequestFactoryInterface $requestFactory)
     {

--- a/src/HtaccessClient.php
+++ b/src/HtaccessClient.php
@@ -29,17 +29,16 @@ final class HtaccessClient
     public function test(
         string $url,
         string $htaccess,
-        ?string $referrer = '',
-        ?string $serverName = ''
+        ?ServerVariables $serverVariables = null
     ): HtaccessResult {
+        $serverVariables = $serverVariables ?? ServerVariables::empty();
         $responseData = $this->request(
             'POST',
             '',
             [
                 'url' => $url,
                 'htaccess' => $htaccess,
-                'referrer' => $referrer ?? '',
-                'serverName' => $serverName ?? '',
+                'serverVariables' => $serverVariables->toArray(),
             ]
         );
 

--- a/src/ServerVariable.php
+++ b/src/ServerVariable.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Madewithlove;
+
+final class ServerVariable
+{
+    public const HTTP_REFERER = 'HTTP_REFERER';
+    public const SERVER_NAME = 'SERVER_NAME';
+
+    public const ALL = [
+        self::HTTP_REFERER,
+        self::SERVER_NAME,
+    ];
+}

--- a/src/ServerVariables.php
+++ b/src/ServerVariables.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Madewithlove;
+
+use InvalidArgumentException;
+
+class ServerVariables
+{
+    private array $variables = [];
+
+    private function __construct()
+    {
+    }
+
+    public static function empty(): self
+    {
+        return new self();
+    }
+
+    public function with(string $optionName, string $value): self
+    {
+        if (!in_array($optionName, ServerVariable::ALL)) {
+            throw new InvalidArgumentException('Unsupported server variable: ' . $optionName);
+        }
+
+        $clone = clone $this;
+        $clone->variables[$optionName] = $value;
+
+        return $clone;
+    }
+
+    public function has(string $optionName): bool
+    {
+        return isset($this->variables[$optionName]);
+    }
+
+    public function get(string $optionName): string
+    {
+        return $this->variables[$optionName] ?? '';
+    }
+}

--- a/src/ServerVariables.php
+++ b/src/ServerVariables.php
@@ -40,4 +40,9 @@ class ServerVariables
     {
         return $this->variables[$optionName] ?? '';
     }
+
+    public function toArray(): array
+    {
+        return $this->variables;
+    }
 }

--- a/tests/HtaccessClientTest.php
+++ b/tests/HtaccessClientTest.php
@@ -58,7 +58,10 @@ final class HtaccessClientTest extends TestCase
             'http://localhost',
             'RewriteCond %{HTTP_REFERER} http://example.com
              RewriteRule .* /example-page [L]',
-            'http://example.com'
+            ServerVariables::empty()->with(
+                ServerVariable::HTTP_REFERER,
+                'http://example.com'
+            )
         );
 
         $this->assertEquals(
@@ -79,8 +82,10 @@ final class HtaccessClientTest extends TestCase
             'http://localhost',
             'RewriteCond %{SERVER_NAME} example.com
              RewriteRule .* /example-page [L]',
-            null,
-            'example.com'
+            ServerVariables::empty()->with(
+                ServerVariable::SERVER_NAME,
+                'example.com'
+            )
         );
 
         $this->assertEquals(

--- a/tests/ServerVariablesTest.php
+++ b/tests/ServerVariablesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Madewithlove;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ServerVariablesTest extends TestCase
+{
+    /** @test */
+    public function it only allows supported variables(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ServerVariables::empty()->with('foo', 'bar');
+    }
+
+    /** @test */
+    public function it holds supported server variables(): void
+    {
+        $serverVariables = ServerVariables::empty()
+            ->with(ServerVariable::HTTP_REFERER, 'example.com');
+
+        $this->assertTrue($serverVariables->has(ServerVariable::HTTP_REFERER));
+        $this->assertEquals('example.com', $serverVariables->get(ServerVariable::HTTP_REFERER));
+
+        $this->assertFalse($serverVariables->has(ServerVariable::SERVER_NAME));
+        $this->assertEquals('', $serverVariables->get(ServerVariable::SERVER_NAME));
+    }
+}


### PR DESCRIPTION
### Changed
- We now require PHP 7.4 as the minimum version
- Passing server variables now happens according to the new API specification

---
### Todo
- Create a branch of the current `main` and push it as `1.x`
- Add information on server variables to the documentation
- Release this as 2.x after we're confident everything is in place