### PR TITLE
Restrict automerge workflow to dependabot PRs

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -1,17 +1,19 @@
 name: Enable automerge on dependabot PRs
 
 on:
-  # See note below about using pull_request_target
-  pull_request_target:
+    # See note below about using pull_request_target
+    pull_request_target:
 
 jobs:
-  automerge:
-    name: 🚀  Enable automerge on dependabot PRs
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🚀  Enable automerge on dependabot PRs
-        run: gh pr merge --merge --auto "1"
-        env:
-          # A personal access token that you have generated and saved in the
-          # repo or org’s encrypted secrets
-          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTO_MERGE_PERSONAL_ACCESS_TOKEN }}
+    automerge:
+        name: 🚀  Enable automerge on dependabot PRs
+        runs-on: ubuntu-latest
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        steps:
+            - name: 🚀  Enable automerge on dependabot PRs
+              run: gh pr merge --merge --auto "$PR_URL"
+              env:
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  # A personal access token that you have generated and saved in the
+                  # repo or org’s encrypted secrets
+                  GH_TOKEN: ${{ secrets.DEPENDABOT_AUTO_MERGE_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- Aligns `.github/workflows/automerge-dependabot.yml` with the invox reference workflow.
- Adds a job-level `if` condition so the workflow only runs for `dependabot[bot]` PRs.
- Passes the triggering PR's URL via `$PR_URL` env var instead of the hardcoded `"1"` argument.

## Test plan
- [ ] Next dependabot PR triggers the workflow and enables auto-merge on the correct PR.
- [ ] Non-dependabot PRs skip the automerge job.