### PR TITLE
🤖 Add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     interval: daily
     time: "03:30"
   versioning-strategy: widen
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
## Summary
- Adds a `cooldown: { default-days: 7 }` block to the composer entry in `.github/dependabot.yml`
- Delays version updates by 7 days as a supply-chain-attack mitigation — malicious releases tend to be detected and yanked within days, so waiting reduces our exposure
- Security updates bypass cooldown ([per docs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-)), so CVE fixes still flow immediately